### PR TITLE
Replace redis with Registry API for responder worker

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -7,13 +7,6 @@ HOST=127.0.0.1
 # Express port
 PORT=3000
 
-# Database/Queue broker
-BROKER=redis
-
-# Redis connection coptios in one url
-REDIS_URL=redis://127.0.0.1:6379
-
-
 # Workers' results queue prefix
 QUEUE_RESULTS_PREFIX=queue_results:
 

--- a/backend/.eslintignore
+++ b/backend/.eslintignore
@@ -1,0 +1,2 @@
+ecosystem.config.js
+jest.config.js

--- a/backend/src/workers/lib/worker.js
+++ b/backend/src/workers/lib/worker.js
@@ -51,7 +51,7 @@ class Worker {
       } catch (e) {
         console.error(`Worker ${this.name} error`);
         console.error(e);
-        throw new WorkerError(e);
+        process.exit(1);
       }
     }
   }
@@ -67,10 +67,10 @@ class Worker {
     try {
       resp = await axios.get(this.popTaskUrl + workerName, { responseType: 'json' });
     } catch (e) {
-      throw new WorkerError(e);
+      resp = e.response;
     }
 
-    if (resp.status == 505) {
+    if (resp.status >= 500) {
       throw new WorkerError('Registry API error');
     }
     if (resp.status == 202) {

--- a/backend/src/workers/responder/index.js
+++ b/backend/src/workers/responder/index.js
@@ -3,20 +3,11 @@ const env = require('dotenv').config({ path: path.resolve(__dirname, '../../../.
 const {
   Worker, WorkerError
 } = require('../lib/worker');
-const { QueueFactory } = require('queue');
-const broker = require('../../helpers/broker');
-
-/**
- * @const {number} Queue cleaner run interval in milliseconds
- */
-const CLEAN_TIMEOUT = 5 * 60 * 1000;
 
 /**
  * Worker responsible for sending results to WebSocket route. Pushes result to results queue.
  * @class ResponderWorker
  * @extends {Worker}
- * @property {Object} queues Map of queues {id: Queue}
- * @property {Object} _timestams Map of queues' creation time {id: timestamp<number>}
  */
 class ResponderWorker extends Worker {
   /**
@@ -24,33 +15,6 @@ class ResponderWorker extends Worker {
    */
   constructor() {
     super('responder');
-    this.queueConfig = {
-      timeout: env.QUEUE_TIMEOUT,
-      dbClient: broker
-    };
-    this.queues = {};
-    this._timestams = {};
-
-    // Set up unused queues cleaner
-    setInterval(this.cleanQueues, CLEAN_TIMEOUT);
-  }
-
-  /**
-   * Removes unused queue. Every CLEAN_TIMEOUT time loops over queues
-   * and deletes queue if it was created more than CLEAN_TIMEOUT time ago.
-   */
-  cleanQueues() {
-    try {
-      Object.entries(this._timestams).forEach(([id, timestamp]) => {
-        if (Date.now() - timestamp > CLEAN_TIMEOUT) {
-          delete this.queues[id];
-          delete this._timestams[id];
-        }
-      });
-    } catch (e) {
-      console.error('Queue cleaner error');
-      console.error(e);
-    }
   }
 
   /**
@@ -61,18 +25,8 @@ class ResponderWorker extends Worker {
    * @param {string} status.tld Tld
    */
   async respond(id, status) {
-    if (!this.queues[id]) {
-      this.queues[id] = QueueFactory.create(env.BROKER, {
-        queueName: env.QUEUE_RESULTS_PREFIX + id,
-        ...this.queueConfig
-      });
-      this._timestams[id] = Date.now();
-      console.log(`Created queue for ${id}`);
-      console.log(`Queues number: ${Object.keys(this.queues).length}`);
-    }
-
     try {
-      await this.queues[id].push({
+      this.pushTask(env.QUEUE_RESULTS_PREFIX + id, {
         available: status.available,
         tld: status.tld
       });

--- a/backend/src/workers/whois/index.js
+++ b/backend/src/workers/whois/index.js
@@ -1,5 +1,7 @@
 const path = require('path');
-const env = require('dotenv').config({ path: path.resolve(__dirname, '../../../.env') }).parsed;
+
+require('dotenv').config({ path: path.resolve(__dirname, '../../../.env') });
+
 const { Worker } = require('../lib/worker');
 const { checkDomain } = require('./checkDomain');
 
@@ -27,7 +29,7 @@ class WhoisWorker extends Worker {
     try {
       const available = await checkDomain(task.domain, task.tld);
 
-      await this.registry.pushTask('responder', {
+      await this.pushTask('responder', {
         id: task.id,
         tld: task.tld,
         available

--- a/backend/src/workers/zoneCheck/index.js
+++ b/backend/src/workers/zoneCheck/index.js
@@ -1,5 +1,7 @@
 const path = require('path');
-const env = require('dotenv').config({ path: path.resolve(__dirname, '../../../.env') }).parsed;
+
+require('dotenv').config({ path: path.resolve(__dirname, '../../../.env') });
+
 const fs = require('fs');
 const { Worker } = require('../lib/worker');
 


### PR DESCRIPTION
Also:
- queueClean method removed, because don't need to clean queues now
- Fix uncatched Error
- Fix nonexistant `registry.pushTask` call in whois worker